### PR TITLE
Prefix grouped keys in command output

### DIFF
--- a/src/Commands/FindMissingTranslations.php
+++ b/src/Commands/FindMissingTranslations.php
@@ -134,16 +134,19 @@ class FindMissingTranslations extends Command
      * Compare array keys recursively
      * @param array<string, string|array<string, string>> $firstArray
      * @param array<string, string|array<string, string>> $secondArray
+     * @param string|null $prefix
      * @return list<string>
      */
-    private function arrayDiffRecursive(array $firstArray, array $secondArray): array
+    private function arrayDiffRecursive(array $firstArray, array $secondArray, ?string $prefix = null): array
     {
         $outputDiff = [];
 
         foreach ($firstArray as $key => $value) {
+            $fullKey = $prefix !== null ? "{$prefix}.{$key}" : $key;
+
             if (array_key_exists($key, $secondArray)) {
                 if (is_array($value)) {
-                    $recursiveDiff = $this->arrayDiffRecursive($value, $secondArray[$key]);
+                    $recursiveDiff = $this->arrayDiffRecursive($value, $secondArray[$key], $fullKey);
                     if (count($recursiveDiff)) {
                         foreach ($recursiveDiff as $diff) {
                             $outputDiff[] = $diff;
@@ -151,7 +154,7 @@ class FindMissingTranslations extends Command
                     }
                 }
             } else {
-                $outputDiff[] = $key;
+                $outputDiff[] = $fullKey;
             }
         }
 

--- a/tests/Commands/FindMissingTranslationsTest.php
+++ b/tests/Commands/FindMissingTranslationsTest.php
@@ -33,9 +33,24 @@ final class FindMissingTranslationsTest extends TestCase
         $output = Artisan::output();
 
         $this->assertSame(1, $exitCode);
-        $this->assertStringContainsString('| be     | a.php | OK  |', $output);
-        $this->assertStringContainsString('| es     | a.php | OK  |', $output);
-        $this->assertStringContainsString('| fr     | a.php | OK  |', $output);
+        $this->assertStringContainsString('| be     | a.php | OK ', $output);
+        $this->assertStringContainsString('| es     | a.php | OK ', $output);
+        $this->assertStringContainsString('| fr     | a.php | OK ', $output);
+    }
+
+    #[Test]
+    public function it_reports_about_missing_translation_keys_inside_group(): void
+    {
+        $this->withoutMockingConsoleOutput();
+
+        $dir = __DIR__ . '/unsync_lang_files';
+        $exitCode = $this->artisan("translations:missing --dir=$dir --base=en");
+        $output = Artisan::output();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('| be     | a.php | group.Help ', $output);
+        $this->assertStringContainsString('| es     | a.php | group.Help ', $output);
+        $this->assertStringContainsString('| fr     | a.php | group.Help ', $output);
     }
 
     #[Test]
@@ -48,9 +63,9 @@ final class FindMissingTranslationsTest extends TestCase
         $output = Artisan::output();
 
         $this->assertSame(1, $exitCode);
-        $this->assertStringContainsString('| be     | a.php | OK  |', $output);
-        $this->assertStringContainsString('| es     | a.php | OK  |', $output);
-        $this->assertStringNotContainsString('| fr     | a.php | OK  |', $output);
+        $this->assertStringContainsString('| be     | a.php | OK ', $output);
+        $this->assertStringContainsString('| es     | a.php | OK ', $output);
+        $this->assertStringNotContainsString('| fr     | a.php | OK ', $output);
     }
 
     #[Test]
@@ -63,8 +78,8 @@ final class FindMissingTranslationsTest extends TestCase
         $output = Artisan::output();
 
         $this->assertSame(1, $exitCode);
-        $this->assertStringNotContainsString('| be     | a.php | OK  |', $output);
-        $this->assertStringContainsString('| es     | a.php | OK  |', $output);
-        $this->assertStringNotContainsString('| fr     | a.php | OK  |', $output);
+        $this->assertStringNotContainsString('| be     | a.php | OK ', $output);
+        $this->assertStringContainsString('| es     | a.php | OK ', $output);
+        $this->assertStringNotContainsString('| fr     | a.php | OK ', $output);
     }
 }

--- a/tests/Commands/unsync_lang_files/be/a.php
+++ b/tests/Commands/unsync_lang_files/be/a.php
@@ -5,5 +5,7 @@ return [
     'No' => 'Не',
     // 'OK' => 'OK', missing key
 
-    // 'group' => [], // missing group
+    'group' => [
+        // missing group key
+    ],
 ];

--- a/tests/Commands/unsync_lang_files/en/a.php
+++ b/tests/Commands/unsync_lang_files/en/a.php
@@ -4,4 +4,8 @@ return [
     'Yes' => 'Yes',
     'No' => 'No',
     'OK' => 'OK',
+
+    'group' => [
+        'Help' => 'Help',
+    ],
 ];

--- a/tests/Commands/unsync_lang_files/es/a.php
+++ b/tests/Commands/unsync_lang_files/es/a.php
@@ -5,5 +5,7 @@ return [
     'No' => 'No',
     // 'OK' => 'OK', missing key
 
-    // 'group' => [], // missing group
+    'group' => [
+        // missing group key
+    ],
 ];

--- a/tests/Commands/unsync_lang_files/fr/a.php
+++ b/tests/Commands/unsync_lang_files/fr/a.php
@@ -6,5 +6,7 @@ return [
     'No' => 'Non',
     // 'OK' => 'OK', missing key
 
-    // 'group' => [], // missing group
+    'group' => [
+        // missing group key
+    ],
 ];


### PR DESCRIPTION
Hi,

This PR changes the output of the command adding the group prefix to nested keys.

Example with this input:
```php
// en/a.php
return [
    'group' => [
        'Help' => 'Help',
    ]
];
```

```php
// b2/a.php
return [
    'group' => [
        // missing Help key
    ]
];
```

Previous output:
```
| be | a.php | Help |
```

After this changes:
```
| be | a.php | group.Help |
```
