### PR TITLE
Fix a criticial error in FindMissingTranslations.php

### DIFF
--- a/src/Commands/FindMissingTranslations.php
+++ b/src/Commands/FindMissingTranslations.php
@@ -144,7 +144,7 @@ class FindMissingTranslations extends Command
         $outputDiff = [];
 
         foreach ($firstArray as $key => $value) {
-            $fullKey = $prefix === null ? $key : "{$prefix}.{$key}";
+            $fullKey = $prefix === null ? (string) $key : "{$prefix}.{$key}";
 
             if (! array_key_exists($key, $secondArray)) {
                 $outputDiff[] = $fullKey;
@@ -161,7 +161,7 @@ class FindMissingTranslations extends Command
     }
 
     /**
-     * Get filenames of directory
+     * Get filenames of the directory
      * @return list<string> Filenames in a given directory
      */
     private function getFilenames(string $directory): array


### PR DESCRIPTION
It fixes this error:

![image](https://github.com/user-attachments/assets/e7843feb-185c-45ce-95f2-dfa006ed6aec)

Not sure why but translations like this:

```php
return [
    '404' => [
        'resource' => 'The resource you are referencing has been removed or you do not have access to it.',
        'text'     => 'It seems something went wrong.',
        'title'    => '404 :: Page not found',
    ],
];    
```

are treated like a numeric indexed array (`404` is an integer). 